### PR TITLE
Add waitForLoad and areAllLoaded methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .idea
 node_modules
 *.log
-lib
 coverage
 example/dist

--- a/__tests__/__snapshots__/test.js.snap
+++ b/__tests__/__snapshots__/test.js.snap
@@ -213,3 +213,15 @@ exports[`server side rendering es6 1`] = `
   fixture2
 </div>
 `;
+
+exports[`server side rendering es6 waitForLoad/areAllLoaded 1`] = `
+<div>
+  fixture2
+</div>
+`;
+
+exports[`server side rendering waitForLoad/areAllLoaded 1`] = `
+<div>
+  fixture1
+</div>
+`;

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -34,6 +34,7 @@ function MyComponent(props) {
 afterEach(async () => {
   try {
     await Loadable.preloadAll();
+    await Loadable.waitForLoad();
   } catch (err) {}
 });
 
@@ -113,6 +114,38 @@ test('server side rendering es6', async () => {
 
   let component = renderer.create(<LoadableMyComponent prop="baz" />);
 
+  expect(component.toJSON()).toMatchSnapshot(); // serverside
+});
+
+test('server side rendering waitForLoad/areAllLoaded', async () => {
+  let LoadableMyComponent = Loadable({
+    loader: createLoader(400, () => require('../__fixtures__/component')),
+    loading: MyLoadingComponent,
+  });
+
+  let component = renderer.create(<LoadableMyComponent prop="baz" />);
+
+  expect(Loadable.areAllLoaded()).toEqual(false);
+
+  await Loadable.waitForLoad();
+
+  expect(Loadable.areAllLoaded()).toEqual(true);
+  expect(component.toJSON()).toMatchSnapshot(); // serverside
+});
+
+test('server side rendering es6 waitForLoad/areAllLoaded', async () => {
+  let LoadableMyComponent = Loadable({
+    loader: createLoader(400, () => require('../__fixtures__/component.es6')),
+    loading: MyLoadingComponent,
+  });
+
+  let component = renderer.create(<LoadableMyComponent prop="baz" />);
+
+  expect(Loadable.areAllLoaded()).toEqual(false);
+
+  await Loadable.waitForLoad();
+
+  expect(Loadable.areAllLoaded()).toEqual(true);
   expect(component.toJSON()).toMatchSnapshot(); // serverside
 });
 

--- a/lib/babel.js
+++ b/lib/babel.js
@@ -1,0 +1,73 @@
+'use strict';
+
+exports.__esModule = true;
+
+exports.default = function (_ref) {
+  var t = _ref.types,
+      template = _ref.template;
+
+  return {
+    visitor: {
+      ImportDeclaration: function ImportDeclaration(path) {
+        var source = path.node.source.value;
+        if (source !== 'react-loadable') return;
+
+        var defaultSpecifier = path.get('specifiers').find(function (specifier) {
+          return specifier.isImportDefaultSpecifier();
+        });
+
+        if (!defaultSpecifier) return;
+
+        var bindingName = defaultSpecifier.node.local.name;
+        var binding = path.scope.getBinding(bindingName);
+
+        binding.referencePaths.forEach(function (refPath) {
+          var callExpression = refPath.parentPath;
+
+          if (callExpression.isMemberExpression() && callExpression.node.computed === false && callExpression.get('property').isIdentifier({ name: 'Map' })) {
+            callExpression = callExpression.parentPath;
+          }
+
+          if (!callExpression.isCallExpression()) return;
+
+          var args = callExpression.get('arguments');
+          if (args.length !== 1) throw callExpression.error;
+
+          var options = args[0];
+          if (!options.isObjectExpression()) return;
+
+          var properties = options.get('properties');
+          var propertiesMap = {};
+
+          properties.forEach(function (property) {
+            var key = property.get('key');
+            propertiesMap[key.node.name] = property;
+          });
+
+          if (propertiesMap.webpack) {
+            return;
+          }
+
+          var loaderMethod = propertiesMap.loader.get('value');
+          var dynamicImports = [];
+
+          loaderMethod.traverse({
+            Import: function Import(path) {
+              dynamicImports.push(path.parentPath);
+            }
+          });
+
+          if (!dynamicImports.length) return;
+
+          propertiesMap.loader.insertAfter(t.objectProperty(t.identifier('webpack'), t.arrowFunctionExpression([], t.arrayExpression(dynamicImports.map(function (dynamicImport) {
+            return t.callExpression(t.memberExpression(t.identifier('require'), t.identifier('resolveWeak')), [dynamicImport.get('arguments')[0].node]);
+          })))));
+
+          propertiesMap.loader.insertAfter(t.objectProperty(t.identifier('modules'), t.arrayExpression(dynamicImports.map(function (dynamicImport) {
+            return dynamicImport.get('arguments')[0].node;
+          }))));
+        });
+      }
+    }
+  };
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,343 @@
+"use strict";
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var React = require("react");
+var PropTypes = require("prop-types");
+
+var ALL_INITIALIZERS = [];
+var READY_INITIALIZERS = [];
+var CONSTRUCTED_INITIALIZERS = [];
+
+function isWebpackReady(getModuleIds) {
+  if ((typeof __webpack_modules__ === "undefined" ? "undefined" : _typeof(__webpack_modules__)) !== "object") {
+    return false;
+  }
+
+  return getModuleIds().every(function (moduleId) {
+    return typeof moduleId !== "undefined" && typeof __webpack_modules__[moduleId] !== "undefined";
+  });
+}
+
+function load(loader) {
+  var promise = loader();
+
+  var state = {
+    loading: true,
+    loaded: null,
+    error: null
+  };
+
+  state.promise = promise.then(function (loaded) {
+    state.loading = false;
+    state.loaded = loaded;
+    return loaded;
+  }).catch(function (err) {
+    state.loading = false;
+    state.error = err;
+    throw err;
+  });
+
+  return state;
+}
+
+function loadMap(obj) {
+  var state = {
+    loading: false,
+    loaded: {},
+    error: null
+  };
+
+  var promises = [];
+
+  try {
+    Object.keys(obj).forEach(function (key) {
+      var result = load(obj[key]);
+
+      if (!result.loading) {
+        state.loaded[key] = result.loaded;
+        state.error = result.error;
+      } else {
+        state.loading = true;
+      }
+
+      promises.push(result.promise);
+
+      result.promise.then(function (res) {
+        state.loaded[key] = res;
+      }).catch(function (err) {
+        state.error = err;
+      });
+    });
+  } catch (err) {
+    state.error = err;
+  }
+
+  state.promise = Promise.all(promises).then(function (res) {
+    state.loading = false;
+    return res;
+  }).catch(function (err) {
+    state.loading = false;
+    throw err;
+  });
+
+  return state;
+}
+
+function resolve(obj) {
+  return obj && obj.__esModule ? obj.default : obj;
+}
+
+function render(loaded, props) {
+  return React.createElement(resolve(loaded), props);
+}
+
+function createLoadableComponent(loadFn, options) {
+  var _class, _temp;
+
+  if (!options.loading) {
+    throw new Error("react-loadable requires a `loading` component");
+  }
+
+  var opts = _extends({
+    loader: null,
+    loading: null,
+    delay: 200,
+    timeout: null,
+    render: render,
+    webpack: null,
+    modules: null
+  }, options);
+
+  var res = null;
+
+  function init() {
+    if (!res) {
+      res = loadFn(opts.loader);
+    }
+    return res.promise;
+  }
+
+  ALL_INITIALIZERS.push(init);
+
+  if (typeof opts.webpack === "function") {
+    READY_INITIALIZERS.push(function () {
+      if (isWebpackReady(opts.webpack)) {
+        return init();
+      }
+    });
+  }
+
+  return _temp = _class = function (_React$Component) {
+    _inherits(LoadableComponent, _React$Component);
+
+    function LoadableComponent(props) {
+      _classCallCheck(this, LoadableComponent);
+
+      var _this = _possibleConstructorReturn(this, _React$Component.call(this, props));
+
+      _this.retry = function () {
+        _this.setState({ error: null, loading: true, timedOut: false });
+        res = loadFn(opts.loader);
+        _this._loadModule();
+      };
+
+      init();
+      CONSTRUCTED_INITIALIZERS.push(init);
+
+      _this.state = {
+        error: res.error,
+        pastDelay: false,
+        timedOut: false,
+        loading: res.loading,
+        loaded: res.loaded
+      };
+      return _this;
+    }
+
+    LoadableComponent.preload = function preload() {
+      return init();
+    };
+
+    LoadableComponent.prototype.componentWillMount = function componentWillMount() {
+      this._mounted = true;
+      this._loadModule();
+    };
+
+    LoadableComponent.prototype._loadModule = function _loadModule() {
+      var _this2 = this;
+
+      if (this.context.loadable && Array.isArray(opts.modules)) {
+        opts.modules.forEach(function (moduleName) {
+          _this2.context.loadable.report(moduleName);
+        });
+      }
+
+      if (!res.loading) {
+        return;
+      }
+
+      if (typeof opts.delay === "number") {
+        if (opts.delay === 0) {
+          this.setState({ pastDelay: true });
+        } else {
+          this._delay = setTimeout(function () {
+            _this2.setState({ pastDelay: true });
+          }, opts.delay);
+        }
+      }
+
+      if (typeof opts.timeout === "number") {
+        this._timeout = setTimeout(function () {
+          _this2.setState({ timedOut: true });
+        }, opts.timeout);
+      }
+
+      var update = function update() {
+        if (!_this2._mounted) {
+          return;
+        }
+
+        _this2.setState({
+          error: res.error,
+          loaded: res.loaded,
+          loading: res.loading
+        });
+
+        _this2._clearTimeouts();
+      };
+
+      res.promise.then(function () {
+        update();
+      }).catch(function (err) {
+        update();
+      });
+    };
+
+    LoadableComponent.prototype.componentWillUnmount = function componentWillUnmount() {
+      this._mounted = false;
+      this._clearTimeouts();
+    };
+
+    LoadableComponent.prototype._clearTimeouts = function _clearTimeouts() {
+      clearTimeout(this._delay);
+      clearTimeout(this._timeout);
+    };
+
+    LoadableComponent.prototype.render = function render() {
+      if (this.state.loading || this.state.error) {
+        return React.createElement(opts.loading, {
+          isLoading: this.state.loading,
+          pastDelay: this.state.pastDelay,
+          timedOut: this.state.timedOut,
+          error: this.state.error,
+          retry: this.retry
+        });
+      } else if (this.state.loaded) {
+        return opts.render(this.state.loaded, this.props);
+      } else {
+        return null;
+      }
+    };
+
+    return LoadableComponent;
+  }(React.Component), _class.contextTypes = {
+    loadable: PropTypes.shape({
+      report: PropTypes.func.isRequired
+    })
+  }, _temp;
+}
+
+function Loadable(opts) {
+  return createLoadableComponent(load, opts);
+}
+
+function LoadableMap(opts) {
+  if (typeof opts.render !== "function") {
+    throw new Error("LoadableMap requires a `render(loaded, props)` function");
+  }
+
+  return createLoadableComponent(loadMap, opts);
+}
+
+Loadable.Map = LoadableMap;
+
+var Capture = function (_React$Component2) {
+  _inherits(Capture, _React$Component2);
+
+  function Capture() {
+    _classCallCheck(this, Capture);
+
+    return _possibleConstructorReturn(this, _React$Component2.apply(this, arguments));
+  }
+
+  Capture.prototype.getChildContext = function getChildContext() {
+    return {
+      loadable: {
+        report: this.props.report
+      }
+    };
+  };
+
+  Capture.prototype.render = function render() {
+    return React.Children.only(this.props.children);
+  };
+
+  return Capture;
+}(React.Component);
+
+Capture.propTypes = {
+  report: PropTypes.func.isRequired
+};
+Capture.childContextTypes = {
+  loadable: PropTypes.shape({
+    report: PropTypes.func.isRequired
+  }).isRequired
+};
+
+
+Loadable.Capture = Capture;
+
+function flushInitializers(initializers) {
+  var promises = [];
+
+  while (initializers.length) {
+    var init = initializers.pop();
+    promises.push(init());
+  }
+
+  return Promise.all(promises).then(function () {
+    if (initializers.length) {
+      return flushInitializers(initializers);
+    }
+  });
+}
+
+Loadable.preloadAll = function () {
+  return new Promise(function (resolve, reject) {
+    flushInitializers(ALL_INITIALIZERS).then(resolve, reject);
+  });
+};
+
+Loadable.preloadReady = function () {
+  return new Promise(function (resolve, reject) {
+    // We always will resolve, errors should be handled within loading UIs.
+    flushInitializers(READY_INITIALIZERS).then(resolve, resolve);
+  });
+};
+
+Loadable.waitForLoad = function () {
+  return new Promise(function (resolve, reject) {
+    flushInitializers(CONSTRUCTED_INITIALIZERS).then(resolve, reject);
+  });
+};
+
+module.exports = Loadable;

--- a/lib/index.js
+++ b/lib/index.js
@@ -336,15 +336,24 @@ Loadable.preloadReady = function () {
   });
 };
 
+/**
+ * Wait for all loadables to load that've been explicitly initialized.
+ * This is distinct from preloadAll which loads all loadables wether
+ * or not they are ever used.
+ */
 Loadable.waitForLoad = function () {
   return new Promise(function (resolve, reject) {
     flushInitializers(CONSTRUCTED_INITIALIZERS).then(resolve, reject);
   });
 };
 
+/**
+ * Checks to see if all loadables, that have been initialized, have loaded.
+ * To be used in conjunction with waitForLoad.
+ */
 Loadable.areAllLoaded = function () {
   return CONSTRUCTED_RESULTS.every(function (res) {
-    return res.loaded;
+    return !res.loading;
   });
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,7 @@ var PropTypes = require("prop-types");
 var ALL_INITIALIZERS = [];
 var READY_INITIALIZERS = [];
 var CONSTRUCTED_INITIALIZERS = [];
+var CONSTRUCTED_RESULTS = [];
 
 function isWebpackReady(getModuleIds) {
   if ((typeof __webpack_modules__ === "undefined" ? "undefined" : _typeof(__webpack_modules__)) !== "object") {
@@ -152,6 +153,7 @@ function createLoadableComponent(loadFn, options) {
 
       init();
       CONSTRUCTED_INITIALIZERS.push(init);
+      CONSTRUCTED_RESULTS.push(res);
 
       _this.state = {
         error: res.error,
@@ -337,6 +339,12 @@ Loadable.preloadReady = function () {
 Loadable.waitForLoad = function () {
   return new Promise(function (resolve, reject) {
     flushInitializers(CONSTRUCTED_INITIALIZERS).then(resolve, reject);
+  });
+};
+
+Loadable.areAllLoaded = function () {
+  return CONSTRUCTED_RESULTS.every(function (res) {
+    return res.loaded;
   });
 };
 

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -1,0 +1,74 @@
+'use strict';
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var fs = require('fs');
+var path = require('path');
+var url = require('url');
+
+function buildManifest(compiler, compilation) {
+  var context = compiler.options.context;
+  var manifest = {};
+
+  compilation.chunks.forEach(function (chunk) {
+    chunk.files.forEach(function (file) {
+      chunk.forEachModule(function (module) {
+        var id = module.id;
+        var name = typeof module.libIdent === 'function' ? module.libIdent({ context: context }) : null;
+        var publicPath = url.resolve(compilation.outputOptions.publicPath || '', file);
+
+        var currentModule = module;
+        if (module.constructor.name === 'ConcatenatedModule') {
+          currentModule = module.rootModule;
+        }
+        if (!manifest[currentModule.rawRequest]) {
+          manifest[currentModule.rawRequest] = [];
+        }
+
+        manifest[currentModule.rawRequest].push({ id: id, name: name, file: file, publicPath: publicPath });
+      });
+    });
+  });
+
+  return manifest;
+}
+
+var ReactLoadablePlugin = function () {
+  function ReactLoadablePlugin() {
+    var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+    _classCallCheck(this, ReactLoadablePlugin);
+
+    this.filename = opts.filename;
+  }
+
+  ReactLoadablePlugin.prototype.apply = function apply(compiler) {
+    var _this = this;
+
+    compiler.plugin('emit', function (compilation, callback) {
+      var manifest = buildManifest(compiler, compilation);
+      var json = JSON.stringify(manifest, null, 2);
+      var outputDirectory = path.dirname(_this.filename);
+      try {
+        fs.mkdirSync(outputDirectory);
+      } catch (err) {
+        if (err.code !== 'EEXIST') {
+          throw err;
+        }
+      }
+      fs.writeFileSync(_this.filename, json);
+      callback();
+    });
+  };
+
+  return ReactLoadablePlugin;
+}();
+
+function getBundles(manifest, moduleIds) {
+  return moduleIds.reduce(function (bundles, moduleId) {
+    return bundles.concat(manifest[moduleId]);
+  }, []);
+}
+
+exports.ReactLoadablePlugin = ReactLoadablePlugin;
+exports.getBundles = getBundles;

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const PropTypes = require("prop-types");
 
 const ALL_INITIALIZERS = [];
 const READY_INITIALIZERS = [];
+const CONSTRUCTED_INITIALIZERS = [];
 
 function isWebpackReady(getModuleIds) {
   if (typeof __webpack_modules__ !== "object") {
@@ -138,6 +139,7 @@ function createLoadableComponent(loadFn, options) {
     constructor(props) {
       super(props);
       init();
+      CONSTRUCTED_INITIALIZERS.push(init);
 
       this.state = {
         error: res.error,
@@ -312,6 +314,12 @@ Loadable.preloadReady = () => {
   return new Promise((resolve, reject) => {
     // We always will resolve, errors should be handled within loading UIs.
     flushInitializers(READY_INITIALIZERS).then(resolve, resolve);
+  });
+};
+
+Loadable.waitForLoad = () => {
+  return new Promise((resolve, reject) => {
+    flushInitializers(CONSTRUCTED_INITIALIZERS).then(resolve, reject);
   });
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const PropTypes = require("prop-types");
 const ALL_INITIALIZERS = [];
 const READY_INITIALIZERS = [];
 const CONSTRUCTED_INITIALIZERS = [];
+const CONSTRUCTED_RESULTS = [];
 
 function isWebpackReady(getModuleIds) {
   if (typeof __webpack_modules__ !== "object") {
@@ -140,6 +141,7 @@ function createLoadableComponent(loadFn, options) {
       super(props);
       init();
       CONSTRUCTED_INITIALIZERS.push(init);
+      CONSTRUCTED_RESULTS.push(res);
 
       this.state = {
         error: res.error,
@@ -322,5 +324,7 @@ Loadable.waitForLoad = () => {
     flushInitializers(CONSTRUCTED_INITIALIZERS).then(resolve, reject);
   });
 };
+
+Loadable.areAllLoaded = () => CONSTRUCTED_RESULTS.every(res => res.loaded);
 
 module.exports = Loadable;

--- a/src/index.js
+++ b/src/index.js
@@ -319,12 +319,21 @@ Loadable.preloadReady = () => {
   });
 };
 
+/**
+ * Wait for all loadables to load that've been explicitly initialized.
+ * This is distinct from preloadAll which loads all loadables wether
+ * or not they are ever used.
+ */
 Loadable.waitForLoad = () => {
   return new Promise((resolve, reject) => {
     flushInitializers(CONSTRUCTED_INITIALIZERS).then(resolve, reject);
   });
 };
 
-Loadable.areAllLoaded = () => CONSTRUCTED_RESULTS.every(res => res.loaded);
+/**
+ * Checks to see if all loadables, that have been initialized, have loaded.
+ * To be used in conjunction with waitForLoad.
+ */
+Loadable.areAllLoaded = () => CONSTRUCTED_RESULTS.every(res => !res.loading);
 
 module.exports = Loadable;


### PR DESCRIPTION
These methods make it possible to better match our style of dependency loading (where we only want to load the dependencies that're actually needed as part of execution). If we were using a traditional model for SSR then using the normal pattern of react-loadable would be fine but since we re-download and execute all the JS on every request it makes more sense to only download as little as we have to!

I had to add the built files to the repo so that we can import this module using the commit SHA.

I'll have a separate diff with the changes to webapp.

I ran `yarn test` and it passed.