### PR TITLE
Only report if the component is loaded

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -177,13 +177,13 @@ function createLoadableComponent(loadFn, options) {
     LoadableComponent.prototype._loadModule = function _loadModule() {
       var _this2 = this;
 
-      if (this.context.loadable && Array.isArray(opts.modules)) {
-        opts.modules.forEach(function (moduleName) {
-          _this2.context.loadable.report(moduleName);
-        });
-      }
-
       if (!res.loading) {
+        if (this.context.loadable && Array.isArray(opts.modules)) {
+          opts.modules.forEach(function (moduleName) {
+            _this2.context.loadable.report(moduleName);
+          });
+        }
+
         return;
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -168,13 +168,13 @@ function createLoadableComponent(loadFn, options) {
     }
 
     _loadModule() {
-      if (this.context.loadable && Array.isArray(opts.modules)) {
-        opts.modules.forEach(moduleName => {
-          this.context.loadable.report(moduleName);
-        });
-      }
-
       if (!res.loading) {
+        if (this.context.loadable && Array.isArray(opts.modules)) {
+          opts.modules.forEach(moduleName => {
+            this.context.loadable.report(moduleName);
+          });
+        }
+
         return;
       }
 


### PR DESCRIPTION
This change makes it so that we only report modules to preload if the Loadable is already loaded.