### PR TITLE
Ensure that we're mounted before calling setState

### DIFF
--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -298,7 +298,7 @@ describe('preloadReady', () => {
     expect(component.toJSON()).toMatchSnapshot();
   });
 
-  test('delay with 0', () => {
+  test('delay with 0', async () => {
     let LoadableMyComponent = Loadable({
       loader: createLoader(300, () => MyComponent),
       loading: MyLoadingComponent,
@@ -307,7 +307,9 @@ describe('preloadReady', () => {
     });
   
     let loadingComponent = renderer.create(<LoadableMyComponent prop="foo" />);
-  
+
+    await waitFor(0);
+      
     expect(loadingComponent.toJSON()).toMatchSnapshot(); // loading
   });
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -146,6 +146,9 @@ function createLoadableComponent(loadFn, options) {
       var _this = _possibleConstructorReturn(this, _React$Component.call(this, props));
 
       _this.retry = function () {
+        if (!_this._mounted) {
+          return;
+        }
         _this.setState({ error: null, loading: true, timedOut: false });
         res = loadFn(opts.loader);
         _this._loadModule();
@@ -170,8 +173,15 @@ function createLoadableComponent(loadFn, options) {
     };
 
     LoadableComponent.prototype.componentWillMount = function componentWillMount() {
-      this._mounted = true;
       this._loadModule();
+    };
+
+    LoadableComponent.prototype.componentDidMount = function componentDidMount() {
+      this._mounted = true;
+    };
+
+    LoadableComponent.prototype.componentWillUnmount = function componentWillUnmount() {
+      this._mounted = false;
     };
 
     LoadableComponent.prototype._loadModule = function _loadModule() {
@@ -188,18 +198,18 @@ function createLoadableComponent(loadFn, options) {
       }
 
       if (typeof opts.delay === "number") {
-        if (opts.delay === 0) {
-          this.setState({ pastDelay: true });
-        } else {
-          this._delay = setTimeout(function () {
+        this._delay = setTimeout(function () {
+          if (_this2._mounted) {
             _this2.setState({ pastDelay: true });
-          }, opts.delay);
-        }
+          }
+        }, opts.delay);
       }
 
       if (typeof opts.timeout === "number") {
         this._timeout = setTimeout(function () {
-          _this2.setState({ timedOut: true });
+          if (_this2._mounted) {
+            _this2.setState({ timedOut: true });
+          }
         }, opts.timeout);
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -163,8 +163,15 @@ function createLoadableComponent(loadFn, options) {
     }
 
     componentWillMount() {
-      this._mounted = true;
       this._loadModule();
+    }
+
+    componentDidMount() {
+      this._mounted = true;
+    }
+
+    componentWillUnmount() {
+      this._mounted = false;
     }
 
     _loadModule() {
@@ -179,18 +186,18 @@ function createLoadableComponent(loadFn, options) {
       }
 
       if (typeof opts.delay === "number") {
-        if (opts.delay === 0) {
-          this.setState({ pastDelay: true });
-        } else {
-          this._delay = setTimeout(() => {
+        this._delay = setTimeout(() => {
+          if (this._mounted) {
             this.setState({ pastDelay: true });
-          }, opts.delay);
-        }
+          }
+        }, opts.delay);
       }
 
       if (typeof opts.timeout === "number") {
         this._timeout = setTimeout(() => {
-          this.setState({ timedOut: true });
+          if (this._mounted) {
+            this.setState({ timedOut: true });
+          }
         }, opts.timeout);
       }
 
@@ -228,6 +235,9 @@ function createLoadableComponent(loadFn, options) {
     }
 
     retry = () => {
+      if (!this._mounted) {
+        return;
+      }
       this.setState({ error: null, loading: true, timedOut: false });
       res = loadFn(opts.loader);
       this._loadModule();


### PR DESCRIPTION
We were calling setState from `componentWillMount` (via _loadModule).  This diff tweaks the code a bit so that even when `delay = 0` we still defer the `setState` until the next render loop.